### PR TITLE
feat: /users POST API 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,11 @@ module.exports = {
         ignoreTemplateLiterals: true,
       },
     ],
+    "import/no-unresolved": [
+      "error",
+      {
+        ignore: ["^firebase-admin/.+"],
+      },
+    ],
   },
 };

--- a/src/constants/MESSAGE.js
+++ b/src/constants/MESSAGE.js
@@ -1,3 +1,4 @@
-exports.modules = {
+module.exports = {
   UNAUTHORIZED: "Unauthorized",
+  INVALID_INPUT: "Invalid input",
 };

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -7,7 +7,7 @@ const loadHttpServer = require("./server");
 
 const indexRouter = require("../routes/index");
 
-const initLoaders = async (app) => {
+const initLoaders = (app) => {
   logger.info("app start");
 
   loadDatabase();

--- a/src/routes/controllers/user.controller.js
+++ b/src/routes/controllers/user.controller.js
@@ -1,0 +1,33 @@
+const User = require("../../../models/User");
+
+const logger = require("../../../libs/logger");
+
+const findOrCreateUser = async (req, res, next) => {
+  try {
+    const { email, displayName } = req.body;
+    const profileUrl = req.body.profile_url;
+
+    const existUser = await User.findOne({ email }).lean().exec();
+
+    if (existUser) {
+      return res.json(existUser);
+    }
+
+    const newUser = {
+      email,
+      displayName,
+      profileUrl,
+    };
+    const createdUser = await User.create(newUser);
+
+    return res.json(createdUser);
+  } catch (error) {
+    logger.error(error);
+
+    return next(error);
+  }
+};
+
+module.exports = {
+  findOrCreateUser,
+};

--- a/src/routes/controllers/user.controller.js
+++ b/src/routes/controllers/user.controller.js
@@ -1,11 +1,19 @@
+const createError = require("http-errors");
 const User = require("../../../models/User");
 
 const logger = require("../../../libs/logger");
+const { INVALID_INPUT } = require("../../constants/MESSAGE");
 
 const findOrCreateUser = async (req, res, next) => {
   try {
-    const { email, displayName } = req.body;
-    const profileUrl = req.body.profile_url;
+    const { email, displayName, profile_url: profileUrl } = req.body;
+
+    if (!email) {
+      const error = createError(400, `${INVALID_INPUT}: email`);
+      logger.error(error.toString());
+
+      return next(error);
+    }
 
     const existUser = await User.findOne({ email }).lean().exec();
 
@@ -19,10 +27,11 @@ const findOrCreateUser = async (req, res, next) => {
       profileUrl,
     };
     const createdUser = await User.create(newUser);
+    logger.info(`(User.create.createdUser) ${JSON.stringify(createdUser)}`);
 
     return res.json(createdUser);
   } catch (error) {
-    logger.error(error);
+    logger.error(error.toString());
 
     return next(error);
   }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,8 +2,8 @@ const express = require("express");
 
 const router = express.Router();
 
-router.get("/", (req, res, next) => {
-  res.send("홈페이지");
-});
+const userRoute = require("./user.route");
+
+router.use("/users", userRoute);
 
 module.exports = router;

--- a/src/routes/middleware/verifyToken.js
+++ b/src/routes/middleware/verifyToken.js
@@ -16,7 +16,7 @@ const verifyToken = async (req, res, next) => {
 
     next();
   } catch (error) {
-    logger.error(error);
+    logger.error(error.toString());
 
     next(createError(401, UNAUTHORIZED));
   }

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,0 +1,9 @@
+const express = require("express");
+
+const router = express.Router();
+
+const userController = require("./controllers/user.controller");
+
+router.route("/").post(userController.findOrCreateUser);
+
+module.exports = router;


### PR DESCRIPTION
## 작업 사항
- FE에서 user 정보를 POST 요청으로 받아 db에 해당 사용자가 존재하는지 확인 후, 사용자가 존재하면 해당 정보를 응답하며, 존재하지 않는 사용자라면 바로 user document를 생성 후 응답합니다.

## 잘 봐주세요
- 스키마에 들어가는 `profile_url` field이름이 lint rule에 위배되어, 바로 destructuring을 하지 않고 별도의 변수로 선언하였습니다.
- lint rule에 의해, 각 엔드포인트 및 에러처리 구문에 일관되게 `return`을 작성하였습니다.

## PR 전 확인사항
[x] 가장 최신 브랜치를 pull했습니다.
[x] base 브랜치명을 확인했습니다.
[x] 코드 컨벤션을 모두 지켰습니다.
[x] 적절한 라벨이 있습니다.
[x] assignee가 있습니다.

## 비고
- 불필요한 async 선언 삭제함
