### PR TITLE
[2022.11.06] test: channel api 테스트 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 .env
 .DS_Store
 /log
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/models/Channel.js
+++ b/models/Channel.js
@@ -22,7 +22,6 @@ const channelSchema = new mongoose.Schema({
   isActive: {
     type: Boolean,
     required: true,
-    default: true,
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "winston-daily-rotate-file": "^4.7.1"
       },
       "devDependencies": {
+        "axios": "^1.1.3",
         "chai": "^4.3.6",
         "eslint": "^8.25.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -1005,6 +1006,17 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2778,6 +2790,26 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -5582,6 +5614,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -7954,6 +7992,17 @@
       "dev": true,
       "peer": true
     },
+    "axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -9317,6 +9366,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
     },
     "form-data": {
       "version": "4.0.0",
@@ -11398,6 +11453,12 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "*.js": "eslint --fix"
   },
   "devDependencies": {
+    "axios": "^1.1.3",
+    "chai": "^4.3.6",
     "eslint": "^8.25.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
@@ -31,10 +33,9 @@
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
+    "mocha": "^10.1.0",
     "nodemon": "^2.0.20",
     "prettier": "^2.7.1",
-    "chai": "^4.3.6",
-    "mocha": "^10.1.0",
     "supertest": "^6.3.1"
   }
 }

--- a/spec/03-channel.js
+++ b/spec/03-channel.js
@@ -1,0 +1,223 @@
+require("dotenv").config();
+
+const express = require("express");
+const mongoose = require("mongoose");
+const request = require("supertest");
+const { expect } = require("chai");
+
+const initAsyncApp = require("../src/loaders/initAsyncApp");
+const Project = require("../models/Project");
+const Channel = require("../models/Channel");
+
+const {
+  testDbConnect,
+  postLoginAndGetCookie,
+  cleanUpTestDatabase,
+} = require("./utils");
+
+const { MESSAGE, LIMITED_CHANNEL_COUNT } = require("../src/constants");
+
+const TEST_CHANNEL = {
+  title: "test",
+  description: "test",
+  isActive: true,
+};
+
+let server = null;
+let projectId = "";
+
+describe("* channels API", () => {
+  before(async () => {
+    const newProject = {
+      title: "test",
+    };
+
+    const app = await initAsyncApp(express());
+    server = request.agent(app);
+
+    await testDbConnect();
+
+    const postLoginResponse = await postLoginAndGetCookie(server);
+    const sessionCookie = postLoginResponse.headers["set-cookie"][0];
+    await server.set("Cookie", sessionCookie);
+
+    const postProjectResponse = await server
+      .post("/projects")
+      .send(newProject)
+      .expect(200);
+
+    projectId = postProjectResponse.body.id;
+  });
+
+  after(async () => {
+    await cleanUpTestDatabase();
+    await mongoose.disconnect();
+  });
+
+  describe("[POST] /projects/:projectId/channels", () => {
+    afterEach(async () => {
+      await Channel.deleteMany({});
+      await Project.findByIdAndUpdate(projectId, { channels: [] });
+    });
+
+    it("요청 성공시, 200 코드와 채널 id를 응답", async () => {
+      const response = await server
+        .post(`/projects/${projectId}/channels`)
+        .send(TEST_CHANNEL)
+        .expect(200);
+
+      const createdChannelId = response.body.id;
+
+      expect(response.body).to.haveOwnProperty("id");
+      expect(mongoose.Types.ObjectId.isValid(createdChannelId)).to.be.true;
+
+      const allChannels = await Channel.find({});
+      const createdChannel = await Channel.findById(createdChannelId);
+
+      expect(allChannels.length).to.equal(1);
+      expect(createdChannel.title).to.equal(TEST_CHANNEL.title);
+    });
+
+    it("projectId가 올바르지 않을 시, 400 코드와 에러 메시지를 응답", async () => {
+      const response = await server
+        .post("/projects/invalidProjectId/channels")
+        .send(TEST_CHANNEL)
+        .expect(400);
+
+      expect(response.body).to.haveOwnProperty("message");
+      expect(response.body.message).to.equal(MESSAGE.BAD_REQUEST);
+
+      const allChannels = await Channel.find({});
+      const createdChannel = await Channel.findOne({
+        title: TEST_CHANNEL.title,
+      });
+
+      expect(allChannels.length).to.equal(0);
+      expect(createdChannel).to.be.null;
+    });
+
+    it("채널 생성 갯수 제한을 초과하면, 423 코드와 에러 메시지를 응답", async () => {
+      for (let i = 1; i <= LIMITED_CHANNEL_COUNT; i++) {
+        const newChannel = await new Channel({
+          _id: mongoose.Types.ObjectId(),
+          title: `${TEST_CHANNEL.title}${i}`,
+          isActive: TEST_CHANNEL.isActive,
+        }).save();
+
+        await Project.findByIdAndUpdate(projectId, {
+          $push: { channels: newChannel._id },
+        });
+      }
+
+      const response = await server
+        .post(`/projects/${projectId}/channels`)
+        .send(TEST_CHANNEL)
+        .expect(423);
+
+      expect(response.body).to.haveOwnProperty("message");
+      expect(response.body.message).to.equal(MESSAGE.LIMITED_CHANNEL);
+
+      const allChannels = await Channel.find({});
+      const createdChannel = await Channel.findOne({
+        title: TEST_CHANNEL.title,
+      });
+
+      expect(allChannels.length).to.equal(LIMITED_CHANNEL_COUNT);
+      expect(createdChannel).to.be.null;
+    });
+  });
+
+  describe("[PUT] /projects/:projectId/channels/:channelId", () => {
+    let channelId = "";
+
+    beforeEach(async () => {
+      const newChannel = await new Channel({
+        _id: mongoose.Types.ObjectId(),
+        ...TEST_CHANNEL,
+      }).save();
+
+      channelId = newChannel._id;
+    });
+
+    afterEach(async () => {
+      await Channel.deleteMany({});
+    });
+
+    it("요청 성공시, 200 코드와 성공 메시지로 응답하고, 해당 채널의 내용이 수정되어야 함", async () => {
+      const response = await server
+        .put(`/projects/${projectId}/channels/${channelId}`)
+        .send({
+          title: `${TEST_CHANNEL.title} edited`,
+          description: `${TEST_CHANNEL.description} edited`,
+        })
+        .expect(200);
+
+      expect(response.body).to.haveOwnProperty("result");
+      expect(response.body.result).to.equal(MESSAGE.SUCCESS);
+
+      const editedChannel = await Channel.findById(channelId);
+
+      expect(editedChannel.title).to.equal(`${TEST_CHANNEL.title} edited`);
+      expect(editedChannel.description)
+        .to.equal(`${TEST_CHANNEL.description} edited`);
+    });
+
+    it("channelId가 올바르지 않을 시, 400 코드와 에러 메시지로 응답", async () => {
+      const response = await server
+        .put(`/projects/${projectId}/channels/invalidChannelId`)
+        .send({
+          title: `${TEST_CHANNEL.title} edited`,
+        })
+        .expect(400);
+
+      expect(response.body).to.haveOwnProperty("message");
+      expect(response.body.message).to.equal(MESSAGE.BAD_REQUEST);
+    });
+  });
+
+  describe("[DELETE] /projects/:projectId/channels/:channelId", () => {
+    let channelId = "";
+
+    beforeEach(async () => {
+      const newChannel = await new Channel({
+        _id: mongoose.Types.ObjectId(),
+        ...TEST_CHANNEL,
+      }).save();
+
+      channelId = newChannel._id;
+
+      await Project.findByIdAndUpdate(projectId, {
+        $push: { channels: channelId },
+      });
+    });
+
+    afterEach(async () => {
+      await Channel.deleteMany({});
+      await Project.findByIdAndUpdate(projectId, { channels: [] });
+    });
+
+    it("요청 성공시, 200 코드와 성공 메시지로 응답하고, 해당 채널 정보는 존재하지 않아야 함", async () => {
+      const response = await server
+        .delete(`/projects/${projectId}/channels/${channelId}`)
+        .expect(200);
+
+      expect(response.body).to.haveOwnProperty("result");
+      expect(response.body.result).to.equal(MESSAGE.SUCCESS);
+
+      const deletedChannel = await Channel.findById(channelId);
+      const targetProject = await Project.findById(projectId);
+
+      expect(deletedChannel).to.be.null;
+      expect(targetProject.channels.length).to.equal(0);
+    });
+
+    it("channelId가 올바르지 않을 시, 400 코드와 에러 메시지로 응답", async () => {
+      const response = await server
+        .delete(`/projects/${projectId}/channels/invalidChannelId`)
+        .expect(400);
+
+      expect(response.body).to.haveOwnProperty("message");
+      expect(response.body.message).to.equal(MESSAGE.BAD_REQUEST);
+    });
+  });
+});

--- a/spec/utils.js
+++ b/spec/utils.js
@@ -1,4 +1,10 @@
 const mongoose = require('mongoose');
+const axios = require("axios");
+const User = require("../models/User");
+const Project = require('../models/Project');
+const Channel = require('../models/Channel');
+
+const { admin } = require('../config/firebase.config');
 const logger = require('../libs/logger');
 
 module.exports = {
@@ -16,15 +22,32 @@ module.exports = {
       uid: process.env.UID,
     };
 
-    const token = process.env.TOKEN;
+    const token = await admin.auth().createCustomToken(process.env.UID);
+
+    const getGoogleIdToken = await axios({
+      method: 'post',
+      url: `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${process.env.FIREBASE_API_KEY}`,
+      data: {
+        token,
+        returnSecureToken: true,
+      },
+    });
+
+    const { idToken } = getGoogleIdToken.data;
 
     const response = await server
       .post("/auth/users")
       .send(googleUserInfo)
-      .set("Authorization", `Bearer ${token}`)
+      .set("Authorization", `Bearer ${idToken}`)
       .expect("set-cookie", /session/)
       .expect(200);
 
     return response;
+  },
+
+  cleanUpTestDatabase: async () => {
+    await User.deleteMany({});
+    await Project.deleteMany({});
+    await Channel.deleteMany({});
   },
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -5,7 +5,9 @@ module.exports = {
     INVALID_INPUT: "Invalid input",
     INVALID_EMAIL: "Please fill a valid email address",
     LIMITED_PROJECT: "The number of projects has reached the limit",
+    LIMITED_CHANNEL: "The number of channels has reached the limit",
     BAD_REQUEST: "Bad request",
+    INTERNAL_SERVER_ERROR: "Internal server error",
   },
   CHANNEL: {
     JOIN: "join",
@@ -18,4 +20,6 @@ module.exports = {
     USER_DISCONNECT: "disconnect-user",
   },
   LIMITED_PROJECT_COUNT: 3,
+  LIMITED_CHANNEL_COUNT: 4,
+  DEFAULT_COOKIE_DURATION: 60 * 60 * 24 * 1 * 1000,
 };

--- a/src/loaders/initAsyncApp.js
+++ b/src/loaders/initAsyncApp.js
@@ -6,6 +6,8 @@ const logger = require("../../libs/logger");
 const loadDatabase = require("./database");
 const indexRouter = require("../routes/index");
 
+const { MESSAGE } = require("../constants");
+
 const initAsyncApp = async (app) => {
   logger.info("app start");
 
@@ -26,7 +28,7 @@ const initAsyncApp = async (app) => {
 
     const error = process.env.NODE_ENV === "development" || err.status
       ? err
-      : new Error("Internal server error");
+      : new Error(MESSAGE.INTERNAL_SERVER_ERROR);
 
     res.status(err.status || 500).json({ message: error.message });
   });

--- a/src/routes/controllers/channel.controller.js
+++ b/src/routes/controllers/channel.controller.js
@@ -26,7 +26,7 @@ const createChannel = async (req, res, next) => {
       .exec();
 
     const channelCount = selectedProject.channels.length;
-    if (channelCount > LIMITED_CHANNEL_COUNT) {
+    if (channelCount >= LIMITED_CHANNEL_COUNT) {
       return next(createError(423, LIMITED_CHANNEL));
     }
 

--- a/src/routes/middlewares/createSessionCookie.js
+++ b/src/routes/middlewares/createSessionCookie.js
@@ -2,7 +2,7 @@ const createError = require("http-errors");
 const { admin } = require("../../../config/firebase.config");
 
 const logger = require("../../../libs/logger");
-const { MESSAGE } = require("../../constants");
+const { MESSAGE, DEFAULT_COOKIE_DURATION } = require("../../constants");
 
 const { UNAUTHORIZED } = MESSAGE;
 
@@ -15,7 +15,7 @@ const createSessionCookie = async (req, res, next) => {
       return next(createError(401, UNAUTHORIZED));
     }
 
-    const expiresIn = 60 * 60 * 24 * 5 * 1000;
+    const expiresIn = DEFAULT_COOKIE_DURATION;
     const sessionCookie = await admin
       .auth()
       .createSessionCookie(token, { expiresIn });


### PR DESCRIPTION
## 작업 사항
- channel api 테스트 코드 작성
- google api를 활용하여 테스트 초기에 인증 쿠키를 받아와 supertest agent에 적용할 수 있도록 postLoginAndGetCookie 함수 수정

기타 수정사항
- Channel schema isActive 디폴트 값 삭제
- 500 에러메시지 상수화(테스트 코드에서도 같은 값을 참조하기 위해서)
- 누락되었던 채널 제한 관련 상수 추가 및 쿠키 지속시간 상수화(기본 지속시간 1일)
- 채널이 4개인 상태일때 더이상 추가가 안되도록 조건 변경(기존의 조건은 채널이 5개가 되어야 생성이 제한되었음)

## 잘 봐주세요
- 테스트 조건들이 적절한지 봐주세요.
- 지난 테스트때 발견되었던 채널 스키마의 잘못된 조건을 변경하였고, 채널 api에서 참조만 되어있고 값은 없었던 상수들을 추가했습니다
- 테스트 환경 정리는 최종적으로 마지막 채널 api에서만 진행하도록 했습니다.

## PR 전 확인사항
* [x] 가장 최신 브랜치를 pull했습니다.
* [x] base 브랜치명을 확인했습니다.
* [x] 코드 컨벤션을 모두 지켰습니다.
* [x] 적절한 라벨이 있습니다.
* [x] assignee가 있습니다.
* [ ] (필요하다면) version 업데이트 했습니다.

## 비고
